### PR TITLE
Check login

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -12,4 +12,9 @@ class ApplicationController < ActionController::Base
   def after_sign_out_path_for(resource)
     new_user_session_path
   end
+
+  def user_logged_in?
+    redirect_to root_path unless user_signed_in?
+    flash[:notice] = "Please loggin."
+  end
 end

--- a/app/controllers/prototypes_controller.rb
+++ b/app/controllers/prototypes_controller.rb
@@ -1,4 +1,5 @@
 class PrototypesController < ApplicationController
+  before_action :user_logged_in?, except: :index
   before_action :set_prototype, only: [:show, :edit, :update,:destroy]
   before_action :set_thumbnail, only: [:edit, :update]
 


### PR DESCRIPTION
## WHAT
ユーザーがログインしていない場合、rootに飛ばされるようにした。

## WHY
current_user.idを使用しているページにいるとき、何らかの理由でsessionが消えるとエラーを吐くため。